### PR TITLE
fix: update gpt-4o model version to 2024-11-20.

### DIFF
--- a/infra/modules/ai-services.bicep
+++ b/infra/modules/ai-services.bicep
@@ -43,7 +43,7 @@ resource chatDeployment 'Microsoft.CognitiveServices/accounts/deployments@2024-0
     model: {
       format: 'OpenAI'
       name: 'gpt-4o'
-      version: '2024-08-06'
+      version: '2024-11-20'
     }
     raiPolicyName: 'Microsoft.DefaultV2'
   }


### PR DESCRIPTION
Updates the gpt-4o model version to `2024-11-20`; previous version `2024-08-06` was deprecated as of 2026-03-30.